### PR TITLE
Fix recommendation when article name is named as directory

### DIFF
--- a/prelims/post.py
+++ b/prelims/post.py
@@ -52,7 +52,8 @@ class Post(object):
             content = self.raw_content.replace(
                 m.group(1),
                 yaml.dump(self.front_matter, allow_unicode=True,
-                          default_flow_style=flow_style)
+                          default_flow_style=flow_style,
+                          sort_keys=False)
             )
             f.write(content)
 

--- a/prelims/processor/recommender.py
+++ b/prelims/processor/recommender.py
@@ -109,4 +109,6 @@ class Recommender(BaseFrontMatterProcessor):
         excluding a file extension.
         """
         file, _ = os.path.splitext(os.path.basename(path))
+        if file == 'index':
+            file = os.path.basename(os.path.dirname(path))
         return urljoin(f'{self.permalink_base}/', f'{file}/')

--- a/prelims/processor/tests/test_recommender.py
+++ b/prelims/processor/tests/test_recommender.py
@@ -14,18 +14,23 @@ class RecommenderTestCase(TestCase):
                 os.path.join(os.sep, 'path', 'to', 'articles', 'a.md'))
         self.path_b = os.path.abspath(
                 os.path.join(os.sep, 'path', 'to', 'articles', 'b.md'))
+        self.path_c = os.path.abspath(
+                os.path.join(os.sep, 'path', 'to', 'articles', 'c', 'index.md'))
 
         # urls
         self.permalink_base = '/diary/post'
         self.permalink_a = '/diary/post/a/'
         self.permalink_b = '/diary/post/b/'
+        self.permalink_c = '/diary/post/c/'
 
     def test_process(self):
         post_a = Post(self.path_a, {'title': 'foo'},
                       '', 'Hello world.', 'utf-8')
         post_b = Post(self.path_b, {'title': 'bar'},
                       '', 'This is a pen.', 'utf-8')
-        posts = [post_a, post_b]
+        post_c = Post(self.path_c, {'title': 'buzz'},
+                      '', 'There is a man in the high castle.', 'utf-8')
+        posts = [post_a, post_b, post_c]
 
         recommender = Recommender(permalink_base=self.permalink_base,
                                   stop_words='english')
@@ -36,14 +41,22 @@ class RecommenderTestCase(TestCase):
             post_a.front_matter['keywords'])
         self.assertEqual(post_a.front_matter, {
             'title': 'foo',
-            'recommendations': [self.permalink_b],
-            'keywords': ['hello', 'pen', 'world']
+            'recommendations': [self.permalink_c, self.permalink_b],
+            'keywords': ['castle', 'hello', 'high', 'man', 'pen', 'world']
         })
 
         post_b.front_matter['keywords'] = sorted(
             post_b.front_matter['keywords'])
         self.assertEqual(post_b.front_matter, {
             'title': 'bar',
-            'recommendations': [self.permalink_a],
-            'keywords': ['hello', 'pen', 'world']
+            'recommendations': [self.permalink_c, self.permalink_a],
+            'keywords': ['castle', 'hello', 'high', 'man', 'pen', 'world']
+        })
+
+        post_c.front_matter['keywords'] = sorted(
+            post_c.front_matter['keywords'])
+        self.assertEqual(post_c.front_matter, {
+            'title': 'buzz',
+            'recommendations': [self.permalink_b, self.permalink_a],
+            'keywords': ['castle', 'hello', 'high', 'man', 'pen', 'world']
         })

--- a/prelims/tests/test_post.py
+++ b/prelims/tests/test_post.py
@@ -8,6 +8,7 @@ import tempfile
 content = """
 ---
 aaa: xxx
+ccc: xxx
 bbb: [xxx]
 ---
 
@@ -50,7 +51,7 @@ class PostTestCase(TestCase):
     def test_load(self):
         post = Post.load(self.mdfile.name, "utf-8")
         self.assertEqual(post.path, self.mdfile.name)
-        self.assertEqual(post.front_matter, {'aaa': 'xxx', 'bbb': ['xxx']})
+        self.assertEqual(post.front_matter, {'aaa': 'xxx', 'ccc': 'xxx', 'bbb': ['xxx']})
         self.assertEqual(post.raw_content, content)
         self.assertEqual(post.content, 'Hello world.')
 
@@ -75,7 +76,7 @@ class PostTestCase(TestCase):
 
         self.assertEqual(post.path, self.mdfile.name)
         self.assertEqual(post.front_matter,
-                         {'aaa': 'xxx', 'bbb': ['zzz'], 'foo': 'bar'})
+                         {'aaa': 'xxx', 'ccc': 'xxx', 'bbb': ['zzz'], 'foo': 'bar'})
 
     def test_save(self):
         post = Post.load(self.mdfile.name, "utf-8")
@@ -85,6 +86,7 @@ class PostTestCase(TestCase):
         expected_content = """
 ---
 aaa: xxx
+ccc: xxx
 bbb: [xxx]
 foo: bar
 ---


### PR DESCRIPTION
This patch aims to fix tiny bugs found after #7 

- Ensure using directory name for recommendation when file name is `index.md` like `/article_name/index.md`
- Stop sorting frontmatter keys on dumping ref: https://github.com/yaml/pyyaml/pull/254