### PR TITLE
Pass ignore special file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 dist/
 *.egg-info/
 .pytest_cache/
+__pycache__/

--- a/prelims/handler.py
+++ b/prelims/handler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 class StaticSitePostsHandler(object):
 
-    def __init__(self, path_dir, encoding='utf-8'):
+    def __init__(self, path_dir, ignore_files=None, encoding='utf-8'):
         assert os.path.isdir(os.path.expanduser(path_dir)), \
             f'path {path_dir} is not a directory or does not exist'
 
@@ -13,6 +13,7 @@ class StaticSitePostsHandler(object):
         self.paths = [p for p in Path(path_dir).rglob('*') if p.suffix in exts]
         self.processors = []
         self.encoding = encoding
+        self.ignore_files = [] if ignore_files is None else ignore_files
 
     def register_processor(self, processor):
         """Add a front matter processor to the queue.
@@ -34,6 +35,9 @@ class StaticSitePostsHandler(object):
         """
         posts = []
         for path in self.paths:
+            if path.name in self.ignore_files:
+                continue
+
             post = Post.load(path, self.encoding)
             if post.is_valid():
                 posts.append(post)

--- a/prelims/processor/recommender.py
+++ b/prelims/processor/recommender.py
@@ -108,7 +108,7 @@ class Recommender(BaseFrontMatterProcessor):
         """Convert a file path into a permalink, which is a part of final URL
         excluding a file extension.
         """
-        file, _ = os.path.splitext(os.path.basename(path))
+        file = path.stem
         if file == 'index':
-            file = os.path.basename(os.path.dirname(path))
+            file = path.parent.name
         return urljoin(f'{self.permalink_base}/', f'{file}/')

--- a/prelims/processor/tests/test_opengraph.py
+++ b/prelims/processor/tests/test_opengraph.py
@@ -4,13 +4,12 @@ from prelims.processor import OpenGraphMediaExtractor
 from unittest import TestCase
 
 import os
-
+from pathlib import Path
 
 class OpenGraphFilePathExtractorTestCase(TestCase):
 
     def setUp(self):
-        self.post_path = os.path.abspath(
-                os.path.join(os.sep, 'path', 'to', 'posts', 'a.md'))
+        self.post_path = Path(f'{os.sep}path').joinpath('to', 'posts', 'a.md')
 
     def test_process(self):
         extractor = OpenGraphMediaExtractor(

--- a/prelims/processor/tests/test_recommender.py
+++ b/prelims/processor/tests/test_recommender.py
@@ -10,9 +10,9 @@ class RecommenderTestCase(TestCase):
 
     def setUp(self):
         # file paths
-        self.path_a = Path('path').joinpath(f'{os.sep}to', 'articles', 'a.md')
-        self.path_b = Path('path').joinpath(f'{os.sep}to', 'articles', 'b.md')
-        self.path_c = Path('path').joinpath(f'{os.sep}to', 'articles', 'c', 'index.md')
+        self.path_a = Path(f'{os.sep}path').joinpath('to', 'articles', 'a.md')
+        self.path_b = Path(f'{os.sep}path').joinpath('to', 'articles', 'b.md')
+        self.path_c = Path(f'{os.sep}path').joinpath('to', 'articles', 'c', 'index.md')
 
         # urls
         self.permalink_base = '/diary/post'

--- a/prelims/processor/tests/test_recommender.py
+++ b/prelims/processor/tests/test_recommender.py
@@ -4,18 +4,15 @@ from prelims.processor import Recommender
 from unittest import TestCase
 
 import os
-
+from pathlib import Path
 
 class RecommenderTestCase(TestCase):
 
     def setUp(self):
         # file paths
-        self.path_a = os.path.abspath(
-                os.path.join(os.sep, 'path', 'to', 'articles', 'a.md'))
-        self.path_b = os.path.abspath(
-                os.path.join(os.sep, 'path', 'to', 'articles', 'b.md'))
-        self.path_c = os.path.abspath(
-                os.path.join(os.sep, 'path', 'to', 'articles', 'c', 'index.md'))
+        self.path_a = Path('path').joinpath(f'{os.sep}to', 'articles', 'a.md')
+        self.path_b = Path('path').joinpath(f'{os.sep}to', 'articles', 'b.md')
+        self.path_c = Path('path').joinpath(f'{os.sep}to', 'articles', 'c', 'index.md')
 
         # urls
         self.permalink_base = '/diary/post'


### PR DESCRIPTION
In some Hugo theme like Wowchemy, there is a special index page to list
all of the section, that is usually named as `_index.md`.

This patch enables to ignore those special file names in Handler.